### PR TITLE
Task to clean up repository checkouts

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -12,5 +12,5 @@ repositories {
 
 dependencies {
     implementation("org.gradle:gradle-tooling-api:7.1.1")
-    implementation("org.eclipse.jgit:org.eclipse.jgit:5.9.0.202009080501-r")
+    implementation("org.eclipse.jgit:org.eclipse.jgit:6.4.0.202211300538-r")
 }

--- a/buildSrc/src/main/kotlin/io/micronaut/build/CleanupGitRepoTask.kt
+++ b/buildSrc/src/main/kotlin/io/micronaut/build/CleanupGitRepoTask.kt
@@ -1,0 +1,25 @@
+package io.micronaut.build
+
+import org.eclipse.jgit.util.FileUtils
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+
+abstract class CleanupGitRepoTask : DefaultTask() {
+
+    @get:Input
+    abstract val repoDirectory: DirectoryProperty
+
+    @TaskAction
+    fun doGit() {
+        val repoDir = repoDirectory.get().asFile
+        if (repoDir.exists() && File(repoDir, ".git").exists()) {
+            println("Deleting ${repoDirectory.get()}")
+            FileUtils.delete(repoDir, 1)
+        } else {
+            println("Repository ${repoDirectory.get()} does not exist")
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/io/micronaut/build/LicenseExtension.kt
+++ b/buildSrc/src/main/kotlin/io/micronaut/build/LicenseExtension.kt
@@ -24,6 +24,7 @@ abstract class LicenseExtension(@Inject val initScript: RegularFile) {
         reportTask.configure {
             projectDirectory.set(checkoutTask.map { it.repoDirectory.get() })
         }
+        createCleanupGitRepoTask(checkoutDir)
     }
 
     fun report(projectDir: File) = tasks.register("reportFor${projectDir.usableName}", GenerateReport::class.java) {
@@ -32,6 +33,10 @@ abstract class LicenseExtension(@Inject val initScript: RegularFile) {
         initScript.set(this@LicenseExtension.initScript)
         projectDirectory.set(projectDir)
         reportDirectory.set(layout.buildDirectory.dir("reports/reportFor${projectDir.usableName}"))
+    }
+
+    fun createCleanupGitRepoTask(checkoutDir: Directory)  = tasks.register("cleanup${checkoutDir.asFile.usableName}", CleanupGitRepoTask::class.java) {
+        this.repoDirectory.set(checkoutDir)
     }
 
     private val String.checkoutDir: String


### PR DESCRIPTION
Created a new gradle task to clean up git repository checkouts. It can be used before generating the report for a different branch/tag version of a repository.