### PR TITLE
Git repository cleanup; Including Micronaut modules

### DIFF
--- a/buildSrc/src/main/kotlin/io/micronaut/build/GenerateReport.kt
+++ b/buildSrc/src/main/kotlin/io/micronaut/build/GenerateReport.kt
@@ -3,6 +3,7 @@ package io.micronaut.build
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.*
 import org.gradle.tooling.GradleConnector
 import java.io.File
@@ -17,6 +18,9 @@ abstract class GenerateReport : DefaultTask() {
     @get:OutputDirectory
     abstract val reportDirectory: DirectoryProperty
 
+    @get:Input
+    abstract val includeMicronautModules: Property<Boolean>
+
     @TaskAction
     fun report() {
         val initScriptPath = initScript.get().asFile.absolutePath
@@ -26,12 +30,12 @@ abstract class GenerateReport : DefaultTask() {
             GradleConnector.newConnector()
                     .forProjectDirectory(projectDir)
                     .connect().use {
-                        it.newBuild()
-                                .withArguments("-I", initScriptPath, "--continue", "--parallel", "--no-configuration-cache")
-                                .forTasks("cleanGenerateLicense", "generateLicense", "licenseReport", "licenseReportText", "licenseReportAggregatedText")
-                                .setStandardOutput(System.out)
-                                .setStandardError(System.err)
-                                .run()
+                    it.newBuild()
+                        .withArguments("-I", initScriptPath, "--continue", "--parallel", "--no-configuration-cache", "-PincludeMicronautModules=" + includeMicronautModules.get())
+                        .forTasks("cleanGenerateLicense", "generateLicense", "licenseReport", "licenseReportText", "licenseReportAggregatedText")
+                        .setStandardOutput(System.out)
+                        .setStandardError(System.err)
+                        .run()
                     }
         } catch (e: Exception) {
             // We intentionally ignore the status of the build result

--- a/buildSrc/src/main/kotlin/io/micronaut/build/GitRepoTask.kt
+++ b/buildSrc/src/main/kotlin/io/micronaut/build/GitRepoTask.kt
@@ -1,6 +1,7 @@
 package io.micronaut.build
 
 import org.eclipse.jgit.api.Git
+import org.eclipse.jgit.util.FileUtils
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.Property
@@ -19,9 +20,17 @@ abstract class GitRepoTask : DefaultTask() {
     @get:Input
     abstract val branch: Property<String>
 
+    @get:Input
+    abstract val cleanupGitRepo: Property<Boolean>
+
     @TaskAction
     fun doGit() {
         val repoDir = repoDirectory.get().asFile
+        if (cleanupGitRepo.get()
+            && repoDir.exists() && File(repoDir, ".git").exists()) {
+            println("Deleting ${repoDirectory.get()}")
+            FileUtils.delete(repoDir, 1)
+        }
         if (repoDir.exists() && File(repoDir, ".git").exists()) {
             println("Updating ${uri.get()}")
             Git.open(repoDir)

--- a/buildSrc/src/main/kotlin/io/micronaut/build/GitRepoTask.kt
+++ b/buildSrc/src/main/kotlin/io/micronaut/build/GitRepoTask.kt
@@ -5,10 +5,12 @@ import org.eclipse.jgit.util.FileUtils
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 import java.io.File
+import javax.inject.Inject
 
 abstract class GitRepoTask : DefaultTask() {
     @get:Input
@@ -20,14 +22,14 @@ abstract class GitRepoTask : DefaultTask() {
     @get:Input
     abstract val branch: Property<String>
 
-    @get:Input
-    abstract val cleanupGitRepo: Property<Boolean>
+    @get:Inject
+    abstract val providers: ProviderFactory
 
     @TaskAction
     fun doGit() {
         val repoDir = repoDirectory.get().asFile
-        if (cleanupGitRepo.get()
-            && repoDir.exists() && File(repoDir, ".git").exists()) {
+        val cleanupGitRepo = providers.gradleProperty("cleanupGitRepo").map(String::toBoolean).getOrElse(false)
+        if (cleanupGitRepo && repoDir.exists() && File(repoDir, ".git").exists()) {
             println("Deleting ${repoDirectory.get()}")
             FileUtils.delete(repoDir, 1)
         }

--- a/buildSrc/src/main/kotlin/io/micronaut/build/LicenseExtension.kt
+++ b/buildSrc/src/main/kotlin/io/micronaut/build/LicenseExtension.kt
@@ -19,7 +19,6 @@ abstract class LicenseExtension(@Inject val initScript: RegularFile) {
             this.repoDirectory.set(checkoutDir)
             this.branch.set(branch)
             this.uri.set(uri)
-            this.cleanupGitRepo.set("true".equals(project.findProperty("cleanupGitRepo") ?: "false"))
         }
         val reportTask = report(checkoutDir.asFile)
         reportTask.configure {
@@ -34,7 +33,6 @@ abstract class LicenseExtension(@Inject val initScript: RegularFile) {
         initScript.set(this@LicenseExtension.initScript)
         projectDirectory.set(projectDir)
         reportDirectory.set(layout.buildDirectory.dir("reports/reportFor${projectDir.usableName}"))
-        includeMicronautModules.set("true".equals(project.findProperty("includeMicronautModules") ?: "false"))
     }
 
     fun createCleanupGitRepoTask(checkoutDir: Directory)  = tasks.register("cleanup${checkoutDir.asFile.usableName}", CleanupGitRepoTask::class.java) {

--- a/buildSrc/src/main/kotlin/io/micronaut/build/LicenseExtension.kt
+++ b/buildSrc/src/main/kotlin/io/micronaut/build/LicenseExtension.kt
@@ -19,6 +19,7 @@ abstract class LicenseExtension(@Inject val initScript: RegularFile) {
             this.repoDirectory.set(checkoutDir)
             this.branch.set(branch)
             this.uri.set(uri)
+            this.cleanupGitRepo.set("true".equals(project.findProperty("cleanupGitRepo") ?: "false"))
         }
         val reportTask = report(checkoutDir.asFile)
         reportTask.configure {
@@ -33,6 +34,7 @@ abstract class LicenseExtension(@Inject val initScript: RegularFile) {
         initScript.set(this@LicenseExtension.initScript)
         projectDirectory.set(projectDir)
         reportDirectory.set(layout.buildDirectory.dir("reports/reportFor${projectDir.usableName}"))
+        includeMicronautModules.set("true".equals(project.findProperty("includeMicronautModules") ?: "false"))
     }
 
     fun createCleanupGitRepoTask(checkoutDir: Directory)  = tasks.register("cleanup${checkoutDir.asFile.usableName}", CleanupGitRepoTask::class.java) {

--- a/src/init.gradle
+++ b/src/init.gradle
@@ -33,6 +33,7 @@ rootProject {
     def aggregatedText = tasks.register("licenseReportAggregatedText", LicenseReportText) {
         xmlReport = aggregator.flatMap(r -> r.mergedXMLReport)
         textReport = rootProject.layout.buildDirectory.file("licenses/all.txt")
+        includeMicronautModules.set("true".equals(project.findProperty("includeMicronautModules") ?: "false"))
     }
 
     allprojects {
@@ -55,6 +56,7 @@ rootProject {
                             mustRunAfter(singleReport)
                             xmlReport = new File(singleReport.get().licenseDir.asFile.get(), "license.xml")
                             textReport = rootProject.layout.buildDirectory.file("licenses/${pub.groupId}:${pub.artifactId}.txt")
+                            includeMicronautModules.set("true".equals(project.findProperty("includeMicronautModules") ?: "false"))
                         }
                     }
                 }
@@ -189,6 +191,9 @@ abstract class LicenseReportText extends DefaultTask {
     @OutputFile
     abstract RegularFileProperty getTextReport()
 
+    @Input
+    abstract Property<Boolean> getIncludeMicronautModules()
+
     String tryFetchLicense(String connection, String fromComponent) {
         if (!connection) {
             return
@@ -309,7 +314,7 @@ abstract class LicenseReportText extends DefaultTask {
             def components = [] as LinkedHashSet
             xml.components.component.each {
                 def id = it.@id.text()
-                if (id.startsWith('io.micronaut')) {
+                if (!includeMicronautModules.get() && id.startsWith('io.micronaut')) {
                     // skip this component
                     return
                 }

--- a/src/init.gradle
+++ b/src/init.gradle
@@ -26,6 +26,7 @@ initscript {
 
 rootProject {
 
+    def includeMicronautModulesProperty = providers.gradleProperty("includeMicronautModules").map(String::toBoolean).getOrElse(false)
     def aggregator = rootProject.tasks.register("licenseReport", ReportAggregator) {
         jsonAggregatedReport.set(layout.buildDirectory.file("reports/licenseReport/report.json"))
         mergedXMLReport.set(layout.buildDirectory.file("reports/licenseReport/all-licenses.xml"))
@@ -33,7 +34,7 @@ rootProject {
     def aggregatedText = tasks.register("licenseReportAggregatedText", LicenseReportText) {
         xmlReport = aggregator.flatMap(r -> r.mergedXMLReport)
         textReport = rootProject.layout.buildDirectory.file("licenses/all.txt")
-        includeMicronautModules.set("true".equals(project.findProperty("includeMicronautModules") ?: "false"))
+        includeMicronautModules.set(includeMicronautModulesProperty)
     }
 
     allprojects {
@@ -56,7 +57,7 @@ rootProject {
                             mustRunAfter(singleReport)
                             xmlReport = new File(singleReport.get().licenseDir.asFile.get(), "license.xml")
                             textReport = rootProject.layout.buildDirectory.file("licenses/${pub.groupId}:${pub.artifactId}.txt")
-                            includeMicronautModules.set("true".equals(project.findProperty("includeMicronautModules") ?: "false"))
+                            includeMicronautModules.set(includeMicronautModulesProperty)
                         }
                     }
                 }


### PR DESCRIPTION
Added two Gradle project properties, for 

- `-PcleanupGitRepo` - when set to `true`, git checkout folder will be deleted prior to generating the report
- `-PincludeMicronautModules` - when set to `true`, micronaut modules will be included in the report