### PR TITLE
Gradle project property for blacklisting licenses from the report

### DIFF
--- a/buildSrc/src/main/kotlin/io/micronaut/build/GenerateReport.kt
+++ b/buildSrc/src/main/kotlin/io/micronaut/build/GenerateReport.kt
@@ -29,12 +29,13 @@ abstract class GenerateReport : DefaultTask() {
         println("Injecting init script $initScriptPath")
         val projectDir = projectDirectory.get().asFile
         val includeMicronautModules = providers.gradleProperty("includeMicronautModules").map(String::toBoolean).getOrElse(false)
+        val blacklistLicenses = providers.gradleProperty("blacklistLicenses").getOrElse("")
         try {
             GradleConnector.newConnector()
                     .forProjectDirectory(projectDir)
                     .connect().use {
                     it.newBuild()
-                        .withArguments("-I", initScriptPath, "--continue", "--parallel", "--no-configuration-cache", "-PincludeMicronautModules=" + includeMicronautModules)
+                        .withArguments("-I", initScriptPath, "--continue", "--parallel", "--no-configuration-cache", "-PincludeMicronautModules=" + includeMicronautModules,"-PblacklistLicenses="+blacklistLicenses)
                         .forTasks("cleanGenerateLicense", "generateLicense", "licenseReport", "licenseReportText", "licenseReportAggregatedText")
                         .setStandardOutput(System.out)
                         .setStandardError(System.err)

--- a/buildSrc/src/main/kotlin/io/micronaut/build/GenerateReport.kt
+++ b/buildSrc/src/main/kotlin/io/micronaut/build/GenerateReport.kt
@@ -29,13 +29,13 @@ abstract class GenerateReport : DefaultTask() {
         println("Injecting init script $initScriptPath")
         val projectDir = projectDirectory.get().asFile
         val includeMicronautModules = providers.gradleProperty("includeMicronautModules").map(String::toBoolean).getOrElse(false)
-        val blacklistLicenses = providers.gradleProperty("blacklistLicenses").getOrElse("")
+        val excludedModuleIds = providers.gradleProperty("excludedModuleIds").getOrElse("")
         try {
             GradleConnector.newConnector()
                     .forProjectDirectory(projectDir)
                     .connect().use {
                     it.newBuild()
-                        .withArguments("-I", initScriptPath, "--continue", "--parallel", "--no-configuration-cache", "-PincludeMicronautModules=" + includeMicronautModules,"-PblacklistLicenses="+blacklistLicenses)
+                        .withArguments("-I", initScriptPath, "--continue", "--parallel", "--no-configuration-cache", "-PincludeMicronautModules=" + includeMicronautModules,"-PexcludedModuleIds="+excludedModuleIds)
                         .forTasks("cleanGenerateLicense", "generateLicense", "licenseReport", "licenseReportText", "licenseReportAggregatedText")
                         .setStandardOutput(System.out)
                         .setStandardError(System.err)

--- a/src/init.gradle
+++ b/src/init.gradle
@@ -27,6 +27,7 @@ initscript {
 rootProject {
 
     def includeMicronautModulesProperty = providers.gradleProperty("includeMicronautModules").map(String::toBoolean).getOrElse(false)
+    def blacklistLicensesProperty = providers.gradleProperty("blacklistLicenses").getOrElse("")
     def aggregator = rootProject.tasks.register("licenseReport", ReportAggregator) {
         jsonAggregatedReport.set(layout.buildDirectory.file("reports/licenseReport/report.json"))
         mergedXMLReport.set(layout.buildDirectory.file("reports/licenseReport/all-licenses.xml"))
@@ -35,6 +36,7 @@ rootProject {
         xmlReport = aggregator.flatMap(r -> r.mergedXMLReport)
         textReport = rootProject.layout.buildDirectory.file("licenses/all.txt")
         includeMicronautModules.set(includeMicronautModulesProperty)
+        blacklistLicenses.set(blacklistLicensesProperty)
     }
 
     allprojects {
@@ -58,6 +60,7 @@ rootProject {
                             xmlReport = new File(singleReport.get().licenseDir.asFile.get(), "license.xml")
                             textReport = rootProject.layout.buildDirectory.file("licenses/${pub.groupId}:${pub.artifactId}.txt")
                             includeMicronautModules.set(includeMicronautModulesProperty)
+                            blacklistLicenses.set(blacklistLicensesProperty)
                             def modules = configurations.runtimeClasspath
                                     .incoming
                                     .resolutionResult
@@ -217,6 +220,9 @@ abstract class LicenseReportText extends DefaultTask {
 
     @Input
     abstract Property<Boolean> getIncludeMicronautModules()
+
+    @Input
+    abstract Property<String> getBlacklistLicenses()
 
     @Optional
     @Input
@@ -430,6 +436,11 @@ abstract class LicenseReportText extends DefaultTask {
                     }
                     def path = it.@licenseFiles.text()
                     def idForDisplay = removeVersion(id)
+//                  skip blacklisted licenses
+                    def LICENSE_BLACKLIST=blacklistLicenses.get().split(";")
+                    if(LICENSE_BLACKLIST.any {it && idForDisplay.contains(it)}){
+                        return
+                    }
                     writer.println(idForDisplay)
                     writer.println('=' * idForDisplay.length())
                     boolean hasLicenses = false

--- a/src/init.gradle
+++ b/src/init.gradle
@@ -27,7 +27,7 @@ initscript {
 rootProject {
 
     def includeMicronautModulesProperty = providers.gradleProperty("includeMicronautModules").map(String::toBoolean).getOrElse(false)
-    def blacklistLicensesProperty = providers.gradleProperty("blacklistLicenses").getOrElse("")
+    def excludedModuleIdsProperty = providers.gradleProperty("excludedModuleIds").getOrElse("")
     def aggregator = rootProject.tasks.register("licenseReport", ReportAggregator) {
         jsonAggregatedReport.set(layout.buildDirectory.file("reports/licenseReport/report.json"))
         mergedXMLReport.set(layout.buildDirectory.file("reports/licenseReport/all-licenses.xml"))
@@ -36,7 +36,7 @@ rootProject {
         xmlReport = aggregator.flatMap(r -> r.mergedXMLReport)
         textReport = rootProject.layout.buildDirectory.file("licenses/all.txt")
         includeMicronautModules.set(includeMicronautModulesProperty)
-        blacklistLicenses.set(blacklistLicensesProperty)
+        excludedModuleIds.set(excludedModuleIdsProperty)
     }
 
     allprojects {
@@ -60,7 +60,7 @@ rootProject {
                             xmlReport = new File(singleReport.get().licenseDir.asFile.get(), "license.xml")
                             textReport = rootProject.layout.buildDirectory.file("licenses/${pub.groupId}:${pub.artifactId}.txt")
                             includeMicronautModules.set(includeMicronautModulesProperty)
-                            blacklistLicenses.set(blacklistLicensesProperty)
+                            excludedModuleIds.set(excludedModuleIdsProperty)
                             def modules = configurations.runtimeClasspath
                                     .incoming
                                     .resolutionResult
@@ -222,7 +222,7 @@ abstract class LicenseReportText extends DefaultTask {
     abstract Property<Boolean> getIncludeMicronautModules()
 
     @Input
-    abstract Property<String> getBlacklistLicenses()
+    abstract Property<String> getExcludedModuleIds()
 
     @Optional
     @Input
@@ -436,9 +436,9 @@ abstract class LicenseReportText extends DefaultTask {
                     }
                     def path = it.@licenseFiles.text()
                     def idForDisplay = removeVersion(id)
-//                  skip blacklisted licenses
-                    def LICENSE_BLACKLIST=blacklistLicenses.get().split(";")
-                    if(LICENSE_BLACKLIST.any {it && idForDisplay.contains(it)}){
+//                  skip excluded Modules from the licenses report
+                    def excluded_Module_Ids=excludedModuleIds.get().split(";")
+                    if(excluded_Module_Ids.any {it && idForDisplay.contains(it)}){
                         return
                     }
                     writer.println(idForDisplay)


### PR DESCRIPTION
Added Gradle project property `-PblacklistLicenses `- that takes a string of dependencies separated by ‘;’ and remove their licenses from the report.
