### PR TITLE
Fixed the missing licenses for validation-api dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,7 +63,7 @@ licenseReports {
             "micronaut-camel",
             "micronaut-build-plugins",
     ).filter {
-      it.contains("micronaut")
+      it.contains("micronaut-core")
     }.map {
         val (name, branch) = if (it.contains('@')) {
             it.split('@')

--- a/src/init.gradle
+++ b/src/init.gradle
@@ -216,7 +216,7 @@ abstract class LicenseReportText extends DefaultTask {
     public static final String LICENSE_LIST_HEADER = "LICENSES LIST"
     private static final String NOT_FOUND = "License unavailable"
     private static final String[] LICENSE_FILE_PATHS = ["", "src/main/resources/META-INF/"]
-    private static final String[] LICENSE_FILE_NAMES = ["LICENSE", "License", "license", "NOTICE", "Notice", "notice", "COPYRIGHT", "Copyright", "copyright"]
+    private static final String[] LICENSE_FILE_NAMES = ["LICENSE", "License", "license", "NOTICE", "Notice", "notice", "COPYRIGHT", "Copyright", "copyright", "LGPL2.1"]
     private static final String[] LICENSE_FILE_EXTENSIONS = ["", "md", "txt"]
 
     private static final Map<String, String> URL_CACHE = Collections.synchronizedMap([:].withDefault { key ->

--- a/src/init.gradle
+++ b/src/init.gradle
@@ -327,7 +327,7 @@ abstract class LicenseReportText extends DefaultTask {
                 sb.append("${fn}\n")
                 sb.append("-" * fn.length()).append("\n")
                 sb.append(deduplicate(txt, fromComponent)).append("\n\n")
-                seen.add(f.toLowerCase())
+                seen.add(fileName)
             }
         }
         return sb.toString()

--- a/src/init.gradle
+++ b/src/init.gradle
@@ -216,7 +216,7 @@ abstract class LicenseReportText extends DefaultTask {
     public static final String LICENSE_LIST_HEADER = "LICENSES LIST"
     private static final String NOT_FOUND = "License unavailable"
     private static final String[] LICENSE_FILE_PATHS = ["", "src/main/resources/META-INF/"]
-    private static final String[] LICENSE_FILE_NAMES = ["LICENSE", "NOTICE", "COPYRIGHT"]
+    private static final String[] LICENSE_FILE_NAMES = ["LICENSE", "License", "license", "NOTICE", "Notice", "notice", "COPYRIGHT", "Copyright", "copyright"]
     private static final String[] LICENSE_FILE_EXTENSIONS = ["", "md", "txt"]
 
     private static final Map<String, String> URL_CACHE = Collections.synchronizedMap([:].withDefault { key ->
@@ -316,13 +316,18 @@ abstract class LicenseReportText extends DefaultTask {
 
     String tryManyLicenses(String baseUri, String fromComponent) {
         StringBuilder sb = new StringBuilder()
+        Set<String> seen = []
         [LICENSE_FILE_PATHS, LICENSE_FILE_NAMES, LICENSE_FILE_EXTENSIONS].combinations().each { fp, f, ext ->
+            String fileName = f.toLowerCase()
+            if(seen.contains(fileName))
+                return
             def fn = ext ? "${f}.${ext}" : f
             def txt = URL_CACHE.get("${baseUri}/${fp}${fn}")
             if (txt) {
                 sb.append("${fn}\n")
                 sb.append("-" * fn.length()).append("\n")
                 sb.append(deduplicate(txt, fromComponent)).append("\n\n")
+                seen.add(f.toLowerCase())
             }
         }
         return sb.toString()


### PR DESCRIPTION
Some licenses were missing from the report (e.g. for the validation-api dependency) because the file in the git repo was named license.txt, so the script couldn't find it as it only tried the files with all capital letters. The fix should be able to get the license files for all reasonable names