### PR TITLE
Dependency exclusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This project will checkout the various Micronaut modules and perform a transitive dependency license verification to generate a report. It will also generate a dependency tree for all modules and submodules that are being checked out.
 
+# Excluding dependencies
+
+If you want to add dependencies to be excluded from the report, either by full name or by a part of the name (e.g. if you add test, it will remove all dependencies that have test in their name), make a file in the src/resources folder named excluded_deps.txt and put all the dependencies you want excluded separated by a new line (one line, one dependency)
+
 ## How to use
 
 Run `./gradlew licenseReportZip`

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,7 +63,7 @@ licenseReports {
             "micronaut-camel",
             "micronaut-build-plugins",
     ).filter {
-      it.contains("micronaut")
+      it.contains("micronaut-core")
     }.map {
         val (name, branch) = if (it.contains('@')) {
             it.split('@')

--- a/buildSrc/src/main/kotlin/io/micronaut/build/GenerateReport.kt
+++ b/buildSrc/src/main/kotlin/io/micronaut/build/GenerateReport.kt
@@ -36,7 +36,7 @@ abstract class GenerateReport : DefaultTask() {
                     .connect().use {
                     it.newBuild()
                         .withArguments("-I", initScriptPath, "--continue", "--parallel", "--no-configuration-cache", "-PincludeMicronautModules=" + includeMicronautModules, "-PexcludedModuleIds="+excludedModuleIds)
-                        .forTasks("cleanGenerateLicense", "generateLicense", "licenseReport", "licenseReportText", "licenseReportAggregatedText", "dependencyTree")
+                        .forTasks("cleanGenerateLicense", "generateLicense", "dependencyTree", "licenseReport", "licenseReportText", "licenseReportAggregatedText")
                         .setStandardOutput(System.out)
                         .setStandardError(System.err)
                         .run()

--- a/src/init.gradle
+++ b/src/init.gradle
@@ -228,7 +228,7 @@ abstract class LicenseReportText extends DefaultTask {
     private static final String NOT_FOUND = "License unavailable"
     private static final String[] LICENSE_FILE_PATHS = ["", "src/main/resources/META-INF/"]
     private static final String[] JACKSON_LICENSE_FILE_PATHS = ["datatypes/src/main/resources/META-INF/", "dataformat/src/main/resources/META-INF/"]
-    private static final String[] LICENSE_FILE_NAMES = ["LICENSE", "License", "license", "NOTICE", "Notice", "notice", "COPYRIGHT", "Copyright", "copyright"]
+    private static final String[] LICENSE_FILE_NAMES = ["LICENSE", "License", "license", "NOTICE", "Notice", "notice", "COPYRIGHT", "Copyright", "copyright", "LGPL2.1"]
     private static final String[] LICENSE_FILE_EXTENSIONS = ["", "md", "txt"]
 
     private static final Map<String, String> URL_CACHE = Collections.synchronizedMap([:].withDefault { key ->

--- a/src/init.gradle
+++ b/src/init.gradle
@@ -227,8 +227,8 @@ abstract class LicenseReportText extends DefaultTask {
     public static final String LICENSE_LIST_HEADER = "LICENSES LIST"
     private static final String NOT_FOUND = "License unavailable"
     private static final String[] LICENSE_FILE_PATHS = ["", "src/main/resources/META-INF/"]
-    private static final String[] JACKSON_LICENSE_FILE_PATHS = ["datatype/src/main/resources/META-INF/", "dataformat/src/main/resources/META-INF/"]
-    private static final String[] LICENSE_FILE_NAMES = ["LICENSE", "NOTICE", "COPYRIGHT"]
+    private static final String[] JACKSON_LICENSE_FILE_PATHS = ["datatypes/src/main/resources/META-INF/", "dataformat/src/main/resources/META-INF/"]
+    private static final String[] LICENSE_FILE_NAMES = ["LICENSE", "License", "license", "NOTICE", "Notice", "notice", "COPYRIGHT", "Copyright", "copyright"]
     private static final String[] LICENSE_FILE_EXTENSIONS = ["", "md", "txt"]
 
     private static final Map<String, String> URL_CACHE = Collections.synchronizedMap([:].withDefault { key ->
@@ -331,8 +331,10 @@ abstract class LicenseReportText extends DefaultTask {
     }
 
     StringBuilder tryManyLicensesJackson(String baseUri, String fromComponent, Set<String> seen, StringBuilder sb){
+        if(fromComponent.contains("jackson-modules-java8"))
+            baseUri = baseUri - "/master" + "/2.14"
         [JACKSON_LICENSE_FILE_PATHS, LICENSE_FILE_NAMES, LICENSE_FILE_EXTENSIONS].combinations().each { fp, f, ext ->
-            String fileName = ((String) f).toLowerCase()
+            String fileName = f.toLowerCase()
             if(seen.contains(fileName))
                 return
             def fn = ext ? "${f}.${ext}" : f
@@ -351,13 +353,16 @@ abstract class LicenseReportText extends DefaultTask {
         StringBuilder sb = new StringBuilder()
         Set<String> seen = []
         [LICENSE_FILE_PATHS, LICENSE_FILE_NAMES, LICENSE_FILE_EXTENSIONS].combinations().each { fp, f, ext ->
+            String fileName = f.toLowerCase()
+            if(seen.contains(fileName))
+                return
             def fn = ext ? "${f}.${ext}" : f
             def txt = URL_CACHE.get("${baseUri}/${fp}${fn}")
             if (txt) {
                 sb.append("${fn}\n")
                 sb.append("-" * fn.length()).append("\n")
                 sb.append(deduplicate(txt, fromComponent)).append("\n\n")
-                seen.add(((String) f).toLowerCase())
+                seen.add(f.toLowerCase())
             }
         }
         if(fromComponent.toLowerCase().contains("jackson"))
@@ -429,18 +434,20 @@ abstract class LicenseReportText extends DefaultTask {
         def lines = depTreeFile.readLines()
         for(String line in lines){
             String trimmed = line.trim()
-            if(trimmed == "") {
+            if(trimmed == "")
                 return true
-            }
             usableDeps.add(trimmed.toLowerCase())
         }
         return true
     }
 
     boolean checkUsableDep(String depId){
-        if(usableDeps.contains(depId.trim().toLowerCase())) {
+        if (includeMicronautModules.get() && depId.startsWith('io.micronaut')) {
+            println("Micronaut module: ${depId}")
             return true
         }
+        if(usableDeps.contains(depId.trim().toLowerCase()))
+            return true
         return false
     }
 
@@ -472,17 +479,14 @@ abstract class LicenseReportText extends DefaultTask {
             def components = [] as LinkedHashSet
             if (includeMicronautModules.get() && getMicronautModules().isPresent()) {
                 getMicronautModules().get().each {
-                    if(checkUsableDep(it)) {
-                        components << it
-                    }
+                    components << it
                 }
             }
             xml.components.component.each {
                 def id = it.@id.text()
-                if (!includeMicronautModules.get() && id.startsWith('io.micronaut')) {
+                if (!includeMicronautModules.get() && id.startsWith('io.micronaut'))
                     // skip this component
                     return
-                }
                 if(checkUsableDep((String) id))
                     components << id
             }

--- a/src/init.gradle
+++ b/src/init.gradle
@@ -32,20 +32,26 @@ rootProject {
         jsonAggregatedReport.set(layout.buildDirectory.file("reports/licenseReport/report.json"))
         mergedXMLReport.set(layout.buildDirectory.file("reports/licenseReport/all-licenses.xml"))
     }
-    def aggregatedText = tasks.register("licenseReportAggregatedText", LicenseReportText) {
-        xmlReport = aggregator.flatMap(r -> r.mergedXMLReport)
-        textReport = rootProject.layout.buildDirectory.file("licenses/all.txt")
-        includeMicronautModules.set(includeMicronautModulesProperty)
-        excludedModuleIds.set(excludedModuleIdsProperty)
-    }
 
     def dependencyTree = tasks.register("dependencyTree", DependencyTree) {
-        mustRunAfter(aggregatedText)
         Configuration config = project.getConfigurations().findByName("allCodeCoverageReportClassDirectories")
         if(config == null)
             config = project.getConfigurations().findByName("runtimeClasspath")
         rootComponent = config.getIncoming().getResolutionResult().getRoot()
+        def parentDir = rootProject.projectDir.parentFile.parentFile.absolutePath
+        def excludedDeps = new File(parentDir + "/src/resources/excluded_deps.txt")
+        if(excludedDeps.exists())
+            excludedDepsFile = excludedDeps
         dependencyTreeReport = rootProject.layout.buildDirectory.file("licenses/tree_all.txt")
+    }
+
+    def aggregatedText = tasks.register("licenseReportAggregatedText", LicenseReportText) {
+        dependsOn(dependencyTree)
+        depTreePath = rootProject.layout.buildDirectory.get().asFile.absolutePath + "/licenses/tree_all.txt"
+        xmlReport = aggregator.flatMap(r -> r.mergedXMLReport)
+        textReport = rootProject.layout.buildDirectory.file("licenses/all.txt")
+        includeMicronautModules.set(includeMicronautModulesProperty)
+        excludedModuleIds.set(excludedModuleIdsProperty)
     }
 
     allprojects {
@@ -64,8 +70,22 @@ rootProject {
                             mustRunAfter(singleReport)
                             reports.from(new File(singleReport.get().licenseDir.asFile.get(), "license.xml"))
                         }
-                        def licenseReportText = tasks.register("licenseReportText", LicenseReportText) {
+                        def dependencyTreeSubproject = tasks.register("dependencyTree", DependencyTree){
                             mustRunAfter(singleReport)
+                            rootComponent = project.getConfigurations()
+                                    .findByName("runtimeClasspath")
+                                    .getIncoming()
+                                    .getResolutionResult()
+                                    .getRoot()
+                            def parentDir = rootProject.projectDir.parentFile.parentFile.absolutePath
+                            def excludedDeps = new File(parentDir + "/src/resources/excluded_deps.txt")
+                            if(excludedDeps.exists())
+                                excludedDepsFile = excludedDeps
+                            dependencyTreeReport = rootProject.layout.buildDirectory.file("licenses/tree_${pub.groupId}:${pub.artifactId}.txt")
+                        }
+                        def licenseReportText = tasks.register("licenseReportText", LicenseReportText) {
+                            dependsOn(dependencyTreeSubproject)
+                            depTreePath = rootProject.layout.buildDirectory.get().asFile.absolutePath + "/licenses/tree_${pub.groupId}:${pub.artifactId}.txt"
                             xmlReport = new File(singleReport.get().licenseDir.asFile.get(), "license.xml")
                             textReport = rootProject.layout.buildDirectory.file("licenses/${pub.groupId}:${pub.artifactId}.txt")
                             includeMicronautModules.set(includeMicronautModulesProperty)
@@ -82,15 +102,6 @@ rootProject {
                                 micronautModules.addAll(modules)
                             }
                             micronautModules.set(modules)
-                        }
-                        tasks.register("dependencyTree", DependencyTree){
-                            mustRunAfter(licenseReportText)
-                            rootComponent = project.getConfigurations()
-                                    .findByName("runtimeClasspath")
-                                    .getIncoming()
-                                    .getResolutionResult()
-                                    .getRoot()
-                            dependencyTreeReport = rootProject.layout.buildDirectory.file("licenses/tree_${pub.groupId}:${pub.artifactId}.txt")
                         }
                     }
                 }
@@ -216,6 +227,7 @@ abstract class LicenseReportText extends DefaultTask {
     public static final String LICENSE_LIST_HEADER = "LICENSES LIST"
     private static final String NOT_FOUND = "License unavailable"
     private static final String[] LICENSE_FILE_PATHS = ["", "src/main/resources/META-INF/"]
+    private static final String[] JACKSON_LICENSE_FILE_PATHS = ["datatype/src/main/resources/META-INF/", "dataformat/src/main/resources/META-INF/"]
     private static final String[] LICENSE_FILE_NAMES = ["LICENSE", "NOTICE", "COPYRIGHT"]
     private static final String[] LICENSE_FILE_EXTENSIONS = ["", "md", "txt"]
 
@@ -229,6 +241,7 @@ abstract class LicenseReportText extends DefaultTask {
     })
 
     private Map<String, String> licenseToComponent = [:]
+    private Set<String> usableDeps = []
 
     @InputFile
     abstract RegularFileProperty getXmlReport()
@@ -248,6 +261,9 @@ abstract class LicenseReportText extends DefaultTask {
 
     @Internal
     abstract DirectoryProperty getRootDir()
+
+    @Input
+    abstract Property<String> getDepTreePath()
 
     LicenseReportText() {
         rootDir.set(project.rootProject.layout.projectDirectory)
@@ -314,8 +330,26 @@ abstract class LicenseReportText extends DefaultTask {
         idForDisplay
     }
 
+    StringBuilder tryManyLicensesJackson(String baseUri, String fromComponent, Set<String> seen, StringBuilder sb){
+        [JACKSON_LICENSE_FILE_PATHS, LICENSE_FILE_NAMES, LICENSE_FILE_EXTENSIONS].combinations().each { fp, f, ext ->
+            String fileName = ((String) f).toLowerCase()
+            if(seen.contains(fileName))
+                return
+            def fn = ext ? "${f}.${ext}" : f
+            def txt = URL_CACHE.get("${baseUri}/${fp}${fn}")
+            if (txt) {
+                sb.append("${fn}\n")
+                sb.append("-" * fn.length()).append("\n")
+                sb.append(deduplicate(txt, fromComponent)).append("\n\n")
+                seen.add(fileName)
+            }
+        }
+        return sb
+    }
+
     String tryManyLicenses(String baseUri, String fromComponent) {
         StringBuilder sb = new StringBuilder()
+        Set<String> seen = []
         [LICENSE_FILE_PATHS, LICENSE_FILE_NAMES, LICENSE_FILE_EXTENSIONS].combinations().each { fp, f, ext ->
             def fn = ext ? "${f}.${ext}" : f
             def txt = URL_CACHE.get("${baseUri}/${fp}${fn}")
@@ -323,8 +357,11 @@ abstract class LicenseReportText extends DefaultTask {
                 sb.append("${fn}\n")
                 sb.append("-" * fn.length()).append("\n")
                 sb.append(deduplicate(txt, fromComponent)).append("\n\n")
+                seen.add(((String) f).toLowerCase())
             }
         }
+        if(fromComponent.toLowerCase().contains("jackson"))
+            sb = tryManyLicensesJackson(baseUri, fromComponent, seen, sb)
         return sb.toString()
     }
 
@@ -384,10 +421,35 @@ abstract class LicenseReportText extends DefaultTask {
         return licenseFiles
     }
 
+    boolean findUsableDepsFromTree(){
+        File depTreeFile = new File(depTreePath.get())
+        if(!depTreeFile.exists())
+            return false
+
+        def lines = depTreeFile.readLines()
+        for(String line in lines){
+            String trimmed = line.trim()
+            if(trimmed == "") {
+                return true
+            }
+            usableDeps.add(trimmed.toLowerCase())
+        }
+        return true
+    }
+
+    boolean checkUsableDep(String depId){
+        if(usableDeps.contains(depId.trim().toLowerCase())) {
+            return true
+        }
+        return false
+    }
+
     @TaskAction
     void execute() {
         def xmlFile = xmlReport.get().asFile
         def txtFile = textReport.get().asFile
+        if(!findUsableDepsFromTree())
+            return
         txtFile.withWriter { writer ->
             def baseDir = xmlFile.parentFile.toPath()
             def xml = new XmlSlurper()
@@ -410,7 +472,9 @@ abstract class LicenseReportText extends DefaultTask {
             def components = [] as LinkedHashSet
             if (includeMicronautModules.get() && getMicronautModules().isPresent()) {
                 getMicronautModules().get().each {
-                    components << it
+                    if(checkUsableDep(it)) {
+                        components << it
+                    }
                 }
             }
             xml.components.component.each {
@@ -419,7 +483,8 @@ abstract class LicenseReportText extends DefaultTask {
                     // skip this component
                     return
                 }
-                components << id
+                if(checkUsableDep((String) id))
+                    components << id
             }
             components = components.sort()
             components.each {
@@ -508,10 +573,14 @@ abstract class LicenseReportText extends DefaultTask {
 
 abstract class DependencyTree extends DefaultTask{
 
-    private static final String[] excludedDeps = ["jackson-annotations", "bom"]
+    private Set<String> excludedDeps = []
 
     @Input
     abstract Property<ResolvedComponentResult> getRootComponent()
+
+    @Optional
+    @InputFile
+    abstract RegularFileProperty getExcludedDepsFile()
 
     @OutputFile
     abstract RegularFileProperty getDependencyTreeReport()
@@ -526,8 +595,12 @@ abstract class DependencyTree extends DefaultTask{
                 return
             }
 
+            getExcludedDeps()
             seen.add(root.id)
             StringBuilder sb = new StringBuilder()
+
+            if(checkExcludedDeps(root.id))
+                return
 
             sb = printDependencyTreePreorder(root, seen, 0, "", sb)
             def seenSorted = seen.sort{it.displayName}
@@ -547,6 +620,18 @@ abstract class DependencyTree extends DefaultTask{
             }
         }catch(Exception e){
             return
+        }
+    }
+
+    void getExcludedDeps(){
+        if(!excludedDepsFile.isPresent())
+            return
+
+        File exclusionsFile = excludedDepsFile.get().asFile
+        def lines = exclusionsFile.readLines()
+
+        for(String line in lines){
+            excludedDeps.add(line.trim())
         }
     }
 
@@ -619,5 +704,47 @@ abstract class DependencyTree extends DefaultTask{
     @TaskAction
     void execute(){
         printDependencyTree()
+        //tryOptional()
+    }
+
+    void tryOptional(){
+        try {
+            Configuration config = project.getConfigurations().findByName("allCodeCoverageReportClassDirectories")
+            if(config == null)
+                config = project.getConfigurations().findByName("runtimeClasspath")
+            StringBuilder sb = new StringBuilder()
+
+            config.getIncoming().dependencies.each {dep ->
+                config.files(dep).each {file ->
+                    sb.append(file.name + "\n")
+                    findPomFile(file)
+                }
+            }
+        }catch(Exception e){
+            return
+        }
+    }
+
+    void findPomFile(File dependencyFile){
+        def parentDir = dependencyFile.parentFile.parentFile
+
+        if(!parentDir.isDirectory())
+            return
+
+        parentDir.eachFileRecurse {pomFile ->
+            if(pomFile.name.endsWith(".pom"))
+                findOptionalDeps(pomFile)
+        }
+    }
+
+    void findOptionalDeps(File pomFile){
+        def pomXml = new XmlSlurper().parse(pomFile)
+        pomXml.dependencies."*".find{node ->
+            String optional = node.optional.text()
+            if(optional.trim().toLowerCase() == "true") {
+                String depName = node.groupId.text() + ":" + node.artifactId.text() + ":" + node.version.text()
+                //println("depname: " + depName)
+            }
+        }
     }
 }

--- a/src/init.gradle
+++ b/src/init.gradle
@@ -35,19 +35,21 @@ rootProject {
 
     def dependencyTree = tasks.register("dependencyTree", DependencyTree) {
         Configuration config = project.getConfigurations().findByName("allCodeCoverageReportClassDirectories")
-        if(config == null)
+        if(config == null) {
             config = project.getConfigurations().findByName("runtimeClasspath")
+        }
         rootComponent = config.getIncoming().getResolutionResult().getRoot()
         def parentDir = rootProject.projectDir.parentFile.parentFile.absolutePath
         def excludedDeps = new File(parentDir + "/src/resources/excluded_deps.txt")
-        if(excludedDeps.exists())
+        if(excludedDeps.exists()) {
             excludedDepsFile = excludedDeps
+        }
         dependencyTreeReport = rootProject.layout.buildDirectory.file("licenses/tree_all.txt")
     }
 
     def aggregatedText = tasks.register("licenseReportAggregatedText", LicenseReportText) {
         dependsOn(dependencyTree)
-        depTreePath = rootProject.layout.buildDirectory.get().asFile.absolutePath + "/licenses/tree_all.txt"
+        dependencyTreeFile = rootProject.layout.buildDirectory.file("licenses/tree_all.txt")
         xmlReport = aggregator.flatMap(r -> r.mergedXMLReport)
         textReport = rootProject.layout.buildDirectory.file("licenses/all.txt")
         includeMicronautModules.set(includeMicronautModulesProperty)
@@ -79,13 +81,14 @@ rootProject {
                                     .getRoot()
                             def parentDir = rootProject.projectDir.parentFile.parentFile.absolutePath
                             def excludedDeps = new File(parentDir + "/src/resources/excluded_deps.txt")
-                            if(excludedDeps.exists())
+                            if(excludedDeps.exists()) {
                                 excludedDepsFile = excludedDeps
+                            }
                             dependencyTreeReport = rootProject.layout.buildDirectory.file("licenses/tree_${pub.groupId}:${pub.artifactId}.txt")
                         }
                         def licenseReportText = tasks.register("licenseReportText", LicenseReportText) {
                             dependsOn(dependencyTreeSubproject)
-                            depTreePath = rootProject.layout.buildDirectory.get().asFile.absolutePath + "/licenses/tree_${pub.groupId}:${pub.artifactId}.txt"
+                            dependencyTreeFile = rootProject.layout.buildDirectory.file("licenses/tree_${pub.groupId}:${pub.artifactId}.txt")
                             xmlReport = new File(singleReport.get().licenseDir.asFile.get(), "license.xml")
                             textReport = rootProject.layout.buildDirectory.file("licenses/${pub.groupId}:${pub.artifactId}.txt")
                             includeMicronautModules.set(includeMicronautModulesProperty)
@@ -262,8 +265,8 @@ abstract class LicenseReportText extends DefaultTask {
     @Internal
     abstract DirectoryProperty getRootDir()
 
-    @Input
-    abstract Property<String> getDepTreePath()
+    @InputFiles
+    abstract RegularFileProperty getDependencyTreeFile()
 
     LicenseReportText() {
         rootDir.set(project.rootProject.layout.projectDirectory)
@@ -331,12 +334,14 @@ abstract class LicenseReportText extends DefaultTask {
     }
 
     StringBuilder tryManyLicensesJackson(String baseUri, String fromComponent, Set<String> seen, StringBuilder sb){
-        if(fromComponent.contains("jackson-modules-java8"))
+        if(fromComponent.contains("jackson-modules-java8")) {
             baseUri = baseUri - "/master" + "/2.14"
+        }
         [JACKSON_LICENSE_FILE_PATHS, LICENSE_FILE_NAMES, LICENSE_FILE_EXTENSIONS].combinations().each { fp, f, ext ->
             String fileName = f.toLowerCase()
-            if(seen.contains(fileName))
+            if(seen.contains(fileName)) {
                 return
+            }
             def fn = ext ? "${f}.${ext}" : f
             def txt = URL_CACHE.get("${baseUri}/${fp}${fn}")
             if (txt) {
@@ -354,8 +359,9 @@ abstract class LicenseReportText extends DefaultTask {
         Set<String> seen = []
         [LICENSE_FILE_PATHS, LICENSE_FILE_NAMES, LICENSE_FILE_EXTENSIONS].combinations().each { fp, f, ext ->
             String fileName = f.toLowerCase()
-            if(seen.contains(fileName))
+            if(seen.contains(fileName)) {
                 return
+            }
             def fn = ext ? "${f}.${ext}" : f
             def txt = URL_CACHE.get("${baseUri}/${fp}${fn}")
             if (txt) {
@@ -419,23 +425,26 @@ abstract class LicenseReportText extends DefaultTask {
             licenseFiles << licenseFile
         else {
             licenseFile.eachFileRecurse { File file ->
-                if (!file.isDirectory() && file.name.toUpperCase().startsWithAny(LICENSE_FILE_NAMES))
+                if (!file.isDirectory() && file.name.toUpperCase().startsWithAny(LICENSE_FILE_NAMES)) {
                     licenseFiles << file
+                }
             }
         }
         return licenseFiles
     }
 
     boolean findUsableDepsFromTree(){
-        File depTreeFile = new File(depTreePath.get())
-        if(!depTreeFile.exists())
+        File depTreeFile = dependencyTreeFile.get().asFile
+        if(!depTreeFile.exists()) {
             return false
+        }
 
         def lines = depTreeFile.readLines()
         for(String line in lines){
             String trimmed = line.trim()
-            if(trimmed == "")
+            if(trimmed == "") {
                 return true
+            }
             usableDeps.add(trimmed.toLowerCase())
         }
         return true
@@ -443,11 +452,11 @@ abstract class LicenseReportText extends DefaultTask {
 
     boolean checkUsableDep(String depId){
         if (includeMicronautModules.get() && depId.startsWith('io.micronaut')) {
-            println("Micronaut module: ${depId}")
             return true
         }
-        if(usableDeps.contains(depId.trim().toLowerCase()))
+        if(usableDeps.contains(depId.trim().toLowerCase())) {
             return true
+        }
         return false
     }
 
@@ -455,8 +464,9 @@ abstract class LicenseReportText extends DefaultTask {
     void execute() {
         def xmlFile = xmlReport.get().asFile
         def txtFile = textReport.get().asFile
-        if(!findUsableDepsFromTree())
+        if(!findUsableDepsFromTree()) {
             return
+        }
         txtFile.withWriter { writer ->
             def baseDir = xmlFile.parentFile.toPath()
             def xml = new XmlSlurper()
@@ -487,8 +497,9 @@ abstract class LicenseReportText extends DefaultTask {
                 if (!includeMicronautModules.get() && id.startsWith('io.micronaut'))
                     // skip this component
                     return
-                if(checkUsableDep((String) id))
+                if(checkUsableDep((String) id)) {
                     components << id
+                }
             }
             components = components.sort()
             components.each {
@@ -601,24 +612,27 @@ abstract class DependencyTree extends DefaultTask{
                 return
             }
 
-            getExcludedDeps()
+            computeExcludedDeps()
             seen.add(root.id)
             StringBuilder sb = new StringBuilder()
 
-            if(checkExcludedDeps(root.id))
+            if(checkExcludedDeps(root.id)) {
                 return
+            }
 
             sb = printDependencyTreePreorder(root, seen, 0, "", sb)
             def seenSorted = seen.sort{it.displayName}
 
             def depTreeFile = dependencyTreeReport.get().asFile
-            if(!depTreeFile.exists())
+            if(!depTreeFile.exists()) {
                 depTreeFile.createNewFile()
+            }
 
             depTreeFile.withWriter {writer ->
                 seenSorted.each {compId ->
-                    if(!compId.displayName.trim().toLowerCase().startsWith("project"))
+                    if(!compId.displayName.trim().toLowerCase().startsWith("project")) {
                         writer.println(compId.displayName)
+                    }
                 }
 
                 writer.println()
@@ -629,9 +643,10 @@ abstract class DependencyTree extends DefaultTask{
         }
     }
 
-    void getExcludedDeps(){
-        if(!excludedDepsFile.isPresent())
+    void computeExcludedDeps(){
+        if(!excludedDepsFile.isPresent()) {
             return
+        }
 
         File exclusionsFile = excludedDepsFile.get().asFile
         def lines = exclusionsFile.readLines()
@@ -650,8 +665,9 @@ abstract class DependencyTree extends DefaultTask{
         Set<DependencyResult> dependencies = root.getDependencies()
         Set<ComponentIdentifier> seenBranch = []
         sb = printDependency(root, beforeComponent, sb, false, depth, dependencies.isEmpty())
-        if(depth > 0 && !dependencies.isEmpty())
+        if(depth > 0 && !dependencies.isEmpty()) {
             beforeComponent += "|   "
+        }
 
         for(DependencyResult d: dependencies) {
             if (!(d instanceof ResolvedDependencyResult)) {
@@ -663,13 +679,16 @@ abstract class DependencyTree extends DefaultTask{
             ResolvedComponentResult dependencyComponent = ((ResolvedDependencyResult) d).getSelected()
             ComponentIdentifier dependencyId = dependencyComponent.getId()
 
-            if(checkExcludedDeps(dependencyId))
+            if(checkExcludedDeps(dependencyId)) {
                 continue
+            }
 
-            if(seen.add(dependencyId))
+            if(seen.add(dependencyId)) {
                 sb = printDependencyTreePreorder(dependencyComponent, seen, depth + 1, beforeComponent + "    ", sb)
-            else if(!seenBranch.contains(dependencyId))
+            }
+            else if(!seenBranch.contains(dependencyId)) {
                 sb = printDependency(dependencyComponent, beforeComponent + "    ", sb, true, depth + 1, dependencyComponent.getDependencies().isEmpty())
+            }
 
             seenBranch.add(dependencyId)
         }
@@ -678,8 +697,9 @@ abstract class DependencyTree extends DefaultTask{
 
     boolean checkExcludedDeps(ComponentIdentifier dependencyId){
         for(String exclusion in excludedDeps){
-            if(dependencyId.displayName.contains(exclusion))
+            if(dependencyId.displayName.contains(exclusion)) {
                 return true
+            }
         }
         return false
     }
@@ -693,8 +713,9 @@ abstract class DependencyTree extends DefaultTask{
 
         sb.append(beforeComponent)
         if(depth > 0) {
-            if (emptyDependencies)
+            if (emptyDependencies) {
                 sb.append("/--- ")
+            }
             else {
                 sb.append("+--- ")
             }

--- a/src/init.gradle
+++ b/src/init.gradle
@@ -362,7 +362,7 @@ abstract class LicenseReportText extends DefaultTask {
                 sb.append("${fn}\n")
                 sb.append("-" * fn.length()).append("\n")
                 sb.append(deduplicate(txt, fromComponent)).append("\n\n")
-                seen.add(f.toLowerCase())
+                seen.add(fileName)
             }
         }
         if(fromComponent.toLowerCase().contains("jackson"))
@@ -710,47 +710,5 @@ abstract class DependencyTree extends DefaultTask{
     @TaskAction
     void execute(){
         printDependencyTree()
-        //tryOptional()
-    }
-
-    void tryOptional(){
-        try {
-            Configuration config = project.getConfigurations().findByName("allCodeCoverageReportClassDirectories")
-            if(config == null)
-                config = project.getConfigurations().findByName("runtimeClasspath")
-            StringBuilder sb = new StringBuilder()
-
-            config.getIncoming().dependencies.each {dep ->
-                config.files(dep).each {file ->
-                    sb.append(file.name + "\n")
-                    findPomFile(file)
-                }
-            }
-        }catch(Exception e){
-            return
-        }
-    }
-
-    void findPomFile(File dependencyFile){
-        def parentDir = dependencyFile.parentFile.parentFile
-
-        if(!parentDir.isDirectory())
-            return
-
-        parentDir.eachFileRecurse {pomFile ->
-            if(pomFile.name.endsWith(".pom"))
-                findOptionalDeps(pomFile)
-        }
-    }
-
-    void findOptionalDeps(File pomFile){
-        def pomXml = new XmlSlurper().parse(pomFile)
-        pomXml.dependencies."*".find{node ->
-            String optional = node.optional.text()
-            if(optional.trim().toLowerCase() == "true") {
-                String depName = node.groupId.text() + ":" + node.artifactId.text() + ":" + node.version.text()
-                //println("depname: " + depName)
-            }
-        }
     }
 }

--- a/src/resources/excluded_deps.txt
+++ b/src/resources/excluded_deps.txt
@@ -1,5 +1,5 @@
 benchmark
-inject
+inject-
 test
 test-suite
 jackson-annotations

--- a/src/resources/excluded_deps.txt
+++ b/src/resources/excluded_deps.txt
@@ -1,0 +1,8 @@
+benchmark
+inject
+test
+test-suite
+jackson-annotations
+bom
+junit
+spock


### PR DESCRIPTION
Since some dependencies (and all transitive dependencies that come with them) need to be removed from the dependency tree and the license report, I added a file (src/resources/excluded_deps.txt) in which you can write all of the dependencies that you want removed, and they will just get skipped over when generating the dependency tree. If the file doesn't exist, the list of dependencies to remove will be empty, and all of the dependencies will be used. The license report reads all of the dependencies that it can use from the corresponding dependency tree file (because if we just remove the dependencies that are in the file from the license report, some transitive dependencies from the removed dependencies will still be present in the license report) and gets the licenses just for them. If the dependency tree file doesn't exist, that means the whole subproject should be removed, so the license file for it is not generated