### PR TITLE
Fix for removing duplicate Apache licenses (and any other duplicates)

### DIFF
--- a/src/init.gradle
+++ b/src/init.gradle
@@ -279,7 +279,13 @@ abstract class LicenseReportText extends DefaultTask {
         } else {
             idx = connection.indexOf("github.com")
             if (idx > 0) {
-                String path = connection.substring(idx + 10).replaceAll(':', '/') - ".git"
+                String path = connection.substring(idx + 10).replaceAll(':', '/')
+                //Added because of the micrometer dependency with the connection /googleapis/java-common-protos.git/proto-google-common-protos
+                def gitIndex = path.indexOf(".git")
+                if(gitIndex > 0) {
+                    path = path.substring(0, gitIndex)
+                }
+                path -= ".git"
                 baseUri = "https://raw.githubusercontent.com/$path/master"
             }
         }
@@ -296,7 +302,7 @@ abstract class LicenseReportText extends DefaultTask {
     }
 
     String deduplicate(String licenseText, String fromComponent) {
-        String normalized = licenseText.trim()
+        String normalized = licenseText.trim().replaceAll("[\\s\\{\\}\\[\\]\\(\\)]", "").replaceAll("https", "http")
         String cid = licenseToComponent[normalized]
         if (cid) {
             return "Same as " + removeVersion(cid)


### PR DESCRIPTION
Changed the deduplicate method to compare the normalized license text, as there were multiple apache licenses that had very slight differences (https and http, one new line more, different brackets) even though they were essentially the same text. Also added a fix for connections that have /something.git/something_else as the connection, so the script gets the correct connection (problem was the micrometer dependency /googleapis/java-common-protos.git/proto-google-common-protos)