### PR TITLE
Added support for 'checkoutRepo' argument

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,14 @@ plugins {
     id("io.micronaut.build.license-report")
 }
 
+val checkoutRepo : String by project
+
 licenseReports {
+    val checkoutRepositories : List<String> = if (project.hasProperty("checkoutRepo")) checkoutRepo.split(",") else listOf();
+    var repositoryNames : List<String> = checkoutRepositories.map {
+        it.split('@').first();
+    }
+
     listOf(
             "micronaut-core@v3.8.5",
             "micronaut-rxjava3",
@@ -62,6 +69,10 @@ licenseReports {
             "micronaut-maven-plugin",
             "micronaut-camel",
             "micronaut-build-plugins",
+    ).filter {
+        !repositoryNames.contains(it.split('@').first())
+    }.plus(
+        checkoutRepositories
     ).filter {
       it.contains("micronaut-core")
     }.map {


### PR DESCRIPTION
The following PR introduces a new argument `checkoutRepo` which adds new repositories to the report list. It is a comma separated list with syntax `<repo-name>@<version>`. If the repository already exists in the `build.gradle.kts` list, it will be replaced by the one passed via this argument.

Example of usage:
```
./gradlew licenseReportZip -PcheckoutRepo="micronaut-core@v4.0.0"
```