### PR TITLE
fix: remove '.txt' from licenses name

### DIFF
--- a/src/init.gradle
+++ b/src/init.gradle
@@ -605,7 +605,7 @@ abstract class LicenseReportText extends DefaultTask {
             def fn = ext ? "${f}.${ext}" : f
             def txt = URL_CACHE.get("${baseUri}/${fp}${fn}")
             if (txt) {
-                sb = appendLicense(txt, fn, fromComponent, sb)
+                sb = appendLicense(txt, f, fromComponent, sb)
                 seen.add(fileName)
             }
         }
@@ -663,7 +663,7 @@ abstract class LicenseReportText extends DefaultTask {
             def fn = ext ? "${f}.${ext}" : f
             def txt = URL_CACHE.get("${baseUri}/${fp}${fn}")
             if (txt) {
-                sb = appendLicense(txt, fn, fromComponent, sb)
+                sb = appendLicense(txt, f, fromComponent, sb)
                 seen.add(fileName)
             }
         }


### PR DESCRIPTION
This PR fixes license text formatting by removing license file extension from license entries.

before: `Apache-2.0: LICENSE.txt`

after the fix: `Apache-2.0: LICENSE`